### PR TITLE
Use pkill instead of killall for Mountain Lion users

### DIFF
--- a/info.plist
+++ b/info.plist
@@ -7,7 +7,13 @@
 	<key>category</key>
 	<string>SCRIPTS</string>
 	<key>command</key>
-	<string>killall `echo {query} | sed 's/.*\/\(.*\)\.app/\1/'`</string>
+	<string>if [ -e /usr/bin/pkill ]; then
+	pkill -i `echo {query}`
+else
+	killall `echo {query} | sed 's/.*\/\(.*\)\.app/\1/'`
+fi</string>
+	<key>disabled</key>
+	<false/>
 	<key>escapequery</key>
 	<true/>
 	<key>escapequerybackquotes</key>
@@ -25,7 +31,11 @@
 	<key>keyword</key>
 	<string>kill</string>
 	<key>logging</key>
+	<true/>
+	<key>multifileargs</key>
 	<false/>
+	<key>parameter</key>
+	<integer>0</integer>
 	<key>silent</key>
 	<true/>
 	<key>subtitle</key>


### PR DESCRIPTION
Mountain Lion introduce some new Unix commands, "pkill" is one of these new commands and it's a lot more easy to use to kill an application. 

Why pkill is a better choice ? 
Because you don't have to type the exact name of the application (which vary according to languages) and you can omit uppercase... 

"pkill" will kill every app matching the pattern your type, here is an example. You have Google Chrome and Chromium running, you want to kill Chrome, just type : `kill chrome`
If you want to kill both apps, just type : `kill chrom`

PS : I let you update the README !!!
